### PR TITLE
Wait between reads to avoid hitting the read rate limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function getShardIterator (streamName, shardId, options) {
 function readShard (shardIterator) {
   const params = {
     ShardIterator: shardIterator,
-    Limit: 100,
+    Limit: 10000,  // https://github.com/awslabs/amazon-kinesis-client/issues/4#issuecomment-56859367
   }
   kinesis.getRecords(params, (err, data) => {
     if (err) console.log(err, err.stack)
@@ -71,7 +71,10 @@ function readShard (shardIterator) {
         return  // Shard has been closed
       }
 
-      readShard(data.NextShardIterator)
+      setTimeout(function () {
+        readShard(data.NextShardIterator)
+        // idleTimeBetweenReadsInMillis  http://docs.aws.amazon.com/streams/latest/dev/kinesis-low-latency.html
+      }, 2000)
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "author": "Chris Chang <c@crccheck.com> (http://crccheck.com/blog)",
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.6.9",
+    "aws-sdk": "^2.6.15",
     "commander": "^2.9.0",
     "update-notifier": "^1.0.2"
   },
   "devDependencies": {
-    "eslint": "^3.8.0",
+    "eslint": "^3.9.1",
     "eslint-config-standard": "^6.2.0",
-    "eslint-plugin-promise": "^3.0.0",
+    "eslint-plugin-promise": "^3.3.1",
     "eslint-plugin-standard": "^2.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -123,14 +123,18 @@ describe('main', () => {
     })
 
     it('continues to read open shard', () => {
+      const clock = sinon.useFakeTimers()
       const getNextIterator = sinon.stub()
       getNextIterator.onFirstCall().returns('shard iterator')
       getNextIterator.onSecondCall().returns(undefined)
       AWS.Kinesis.prototype.getRecords = (params, cb) =>
-      cb(undefined, {Records: [{Data: ''}], NextShardIterator: getNextIterator()})
+        cb(undefined, {Records: [{Data: ''}], NextShardIterator: getNextIterator()})
       const main = proxyquire('../index', {'aws-sdk': AWS})
       main._readShard()
+      assert.strictEqual(getNextIterator.callCount, 1)
+      clock.tick(10000)  // A number bigger than the idle time
       assert.strictEqual(getNextIterator.callCount, 2)
+      clock.restore()
     })
   })
 })


### PR DESCRIPTION
Fixes 'ProvisionedThroughputExceededException: Rate exceeded for shard'