### PR TITLE
Add --list option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,12 +11,19 @@ const pkg = JSON.parse(fs.readFileSync(`${__dirname}/package.json`))
 program
   .version(pkg.version)
   .arguments('<stream_name>')
+  // XXX --list works as an accident of not specifying a stream_name
+  .option('--list', 'Just list all streams and exit')
   .option('--type-latest', '(DEFAULT) start reading any new data (LATEST)')
   .option('--type-oldest', 'start reading from the oldest data (TRIM_HORIZON)')
   .option('--type-at <sequence_number>', 'start reading from this sequence number (AT_SEQUENCE_NUMBER)')
   .option('--type-after <sequence_number>', 'start reading after this sequence number (AFTER_SEQUENCE_NUMBER)')
   .option('--type-timestamp <timestamp>', 'start reading after this time (units: epoch seconds) (AT_TIMESTAMP)')
   .action((streamName) => {
+    if (program.list) {
+      // Hack program.args to be empty so the getStreams block below will run instead
+      program.args = []
+      return
+    }
     const options = {}
     if (program.typeTimestamp) {
       options.ShardIteratorType = 'AT_TIMESTAMP'

--- a/package.json
+++ b/package.json
@@ -25,19 +25,19 @@
   "author": "Chris Chang <c@crccheck.com> (http://crccheck.com/blog)",
   "license": "Apache-2.0",
   "dependencies": {
-    "aws-sdk": "^2.6.15",
+    "aws-sdk": "^2.7.27",
     "commander": "^2.9.0",
-    "update-notifier": "^1.0.2"
+    "update-notifier": "^1.0.3"
   },
   "devDependencies": {
-    "eslint": "^3.9.1",
+    "eslint": "^3.14.0",
     "eslint-config-standard": "^6.2.0",
-    "eslint-plugin-promise": "^3.3.1",
+    "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.1",
     "istanbul": "^0.4.5",
-    "mocha": "^3.1.2",
+    "mocha": "^3.2.0",
     "proxyquire": "^1.7.10",
-    "sinon": "^1.17.6"
+    "sinon": "^1.17.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Part of #15 It's probably a good idea to have an explicit `--list` option. This way if you see this command in a tool chain or script, it'll be self documenting.