### PR TITLE
Read from multiple shards if there are any

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,14 @@ module.exports._readShard = readShard
 
 module.exports.main = function (streamName, getShardIteratorOptions) {
   getShardId(streamName)
-  // TODO For heavy duty cases, we would  spin up a reader for each shard
-  .then((shardIds) => getShardIterator(streamName, shardIds[0], getShardIteratorOptions))
-  .then((shardIterator) => readShard(shardIterator))
+  .then((shardIds) => {
+    const shardIterators = shardIds.map((shardId) =>
+      getShardIterator(streamName, shardId, getShardIteratorOptions))
+    return Promise.all(shardIterators)
+  })
+  .then((shardIterators) => {
+    shardIterators.forEach((shardIterator) => readShard(shardIterator))
+    // return Promise.all(shardIterators.map((shardIterator) => readShard(shardIterator)))
+  })
   .catch((err) => console.log(err, err.stack))
 }

--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ function getShardId (streamName) {
         reject(err)
       } else {
         if (data.StreamDescription.Shards.length) {
-          // TODO For heavy duty cases, we would return all shard ids and spin
-          // up a reader for each shards
-          resolve(data.StreamDescription.Shards[0].ShardId)
+          resolve(data.StreamDescription.Shards.map((x) => x.ShardId))
         } else {
           reject('No shards!')
         }
@@ -89,7 +87,8 @@ module.exports._readShard = readShard
 
 module.exports.main = function (streamName, getShardIteratorOptions) {
   getShardId(streamName)
-  .then((shardId) => getShardIterator(streamName, shardId, getShardIteratorOptions))
+  // TODO For heavy duty cases, we would  spin up a reader for each shard
+  .then((shardIds) => getShardIterator(streamName, shardIds[0], getShardIteratorOptions))
   .then((shardIterator) => readShard(shardIterator))
   .catch((err) => console.log(err, err.stack))
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "aws-sdk": "^2.7.27",
     "commander": "^2.9.0",
+    "debug": "^2.6.0",
     "update-notifier": "^1.0.3"
   },
   "devDependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -51,7 +51,7 @@ describe('main', () => {
       const main = proxyquire('../index', {'aws-sdk': AWS})
       return main._getShardId()
         .then((data) => {
-          assert.strictEqual(data, 'shard id')
+          assert.ok(false, 'This should never run')
         })
         .catch((err) => {
           assert.strictEqual(err, 'No shards!')
@@ -64,7 +64,7 @@ describe('main', () => {
       const main = proxyquire('../index', {'aws-sdk': AWS})
       return main._getShardId()
         .then((data) => {
-          assert.strictEqual(data, 'shard id')
+          assert.deepEqual(data, ['shard id'])
         })
     })
 


### PR DESCRIPTION
If a shard has multiple shards, read from all of them until they are closed.

Does not handle when new shards are added while reading.

Also adds the `debug` package for logging. It was already a dep of a dep.

Closes #14 