### PR TITLE
Add --new-line option, add --regex-filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ $ kinesis-console-consumer --help
     --type-at <sequence_number>     start reading from this sequence number (AT_SEQUENCE_NUMBER)
     --type-after <sequence_number>  start reading after this sequence number (AFTER_SEQUENCE_NUMBER)
     --type-timestamp <timestamp>    start reading after this time (units: epoch seconds) (AT_TIMESTAMP)
+    --new-line                      print each record to a new line
+    --regex-filter <regexFilter>    filter data using this regular expression
 ```
 
 ### Examples

--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,8 @@ program
   .option('--type-at <sequence_number>', 'start reading from this sequence number (AT_SEQUENCE_NUMBER)')
   .option('--type-after <sequence_number>', 'start reading after this sequence number (AFTER_SEQUENCE_NUMBER)')
   .option('--type-timestamp <timestamp>', 'start reading after this time (units: epoch seconds) (AT_TIMESTAMP)')
+  .option('--new-line', 'print each record to a new line')
+  .option('--regex-filter <regexFilter>', 'filter data using this regular expression')
   .action((streamName) => {
     if (program.list) {
       // Hack program.args to be empty so the getStreams block below will run instead
@@ -46,6 +48,16 @@ program
       options.ShardIteratorType = 'TRIM_HORIZON'
     } else {
       options.ShardIteratorType = 'LATEST'
+    }
+    if(program.newLine) {
+      options.NewLine = true
+    } else {
+      options.Newline = false
+    }
+    if (program.regexFilter) {
+      options.RegexFilter = program.regexFilter
+    } else {
+      options.RegexFilter = ".*"
     }
     const reader = new index.KinesisStreamReader(client, streamName, options)
     reader.pipe(process.stdout)


### PR DESCRIPTION
Messages are hard to read in the console, adding the new line character can make it easier to read. If needing to filter messages and are unable to use commandline to filter, need a regex to filter the messages.