### PR TITLE
Send a "connected" event when done connecting to kinesis

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,7 @@ program
   .option('--type-timestamp <timestamp>', 'start reading after this time (units: epoch seconds) (AT_TIMESTAMP)')
   .option('--no-new-line', "Don't print a new line between records")
   .option('--regex-filter <regexFilter>', 'filter data using this regular expression')
+  .option('--verbose', 'output a message when the stream is succesfully connected')
   .action((streamName) => {
     if (program.list) {
       // Hack program.args to be empty so the getStreams block below will run instead
@@ -54,6 +55,7 @@ program
       options.regexFilter = '.*'
     }
     const reader = new index.KinesisStreamReader(client, streamName, options)
+    if (program.verbose) reader.on("connected", () => process.stdout.write(`Connected to stream: ${streamName}\n`))  
     reader.pipe(process.stdout)
   })
   .parse(process.argv)

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class KinesisStreamReader extends Readable {
       })
       .then((shardIterators) => {
         shardIterators.forEach((shardIterator) => this.readShard(shardIterator))
+        this.emit('connected')
       })
       .catch((err) => {
         this.emit('error', err) || console.log(err, err.stack)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -148,6 +148,19 @@ describe('main', () => {
         return reader._startKinesis('stream name', {})
       })
 
+      it('emits connected event when successfully connected', () => {
+        client.describeStream = AWSPromise.resolve({StreamDescription: {Shards: [{ShardId: 'shard id'}]}})
+        client.getShardIterator = AWSPromise.resolve({ShardIterator: 'shard iterator'})
+
+        sinon.stub(main.KinesisStreamReader.prototype, 'readShard')
+        const reader = new main.KinesisStreamReader(client, 'stream name', {foo: 'bar'})
+
+        return new Promise((resolve) => {
+          reader.once('connected', resolve)
+          reader._startKinesis()
+        })
+      })
+
       xit('logs when there is an error', () => {
         client.describeStream = AWSPromise.reject('lol error')
         const reader = new main.KinesisStreamReader(client, 'stream name', {foo: 'bar'})


### PR DESCRIPTION
Hi 👋 ! Thanks for this library, it's a really low-friction way to experiment with Kinesis / verify that things are working :)

Small change request:

We would like to know when the consumer has successfully completed its handshake with AWS and confirmed that the stream is capable of receiving messages. (This is useful, for instance, in a before hook for an inter-process smoke test that talks to AWS directly.)

(FYI @wwwidmer)